### PR TITLE
Make validator use actual field_names for replacements.

### DIFF
--- a/src/Traits/HasCustomFields.php
+++ b/src/Traits/HasCustomFields.php
@@ -3,6 +3,7 @@
 namespace Givebutter\LaravelCustomFields\Traits;
 
 use Givebutter\LaravelCustomFields\Models\CustomField;
+use Givebutter\LaravelCustomFields\Validators\CustomFieldValidator;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
 
@@ -24,6 +25,6 @@ trait HasCustomFields
                 return ["field_{$key}" => $field];
             })->toArray();
 
-        return Validator::make($keyAdjustedFields, $validationRules);
+        return new CustomFieldValidator($keyAdjustedFields, $validationRules);
     }
 }

--- a/src/Validators/CustomFieldValidator.php
+++ b/src/Validators/CustomFieldValidator.php
@@ -1,0 +1,32 @@
+<?php 
+
+namespace Givebutter\LaravelCustomFields\Validators;
+
+use Givebutter\LaravelCustomFields\Models\CustomField;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Validator;
+
+class CustomFieldValidator extends Validator
+{
+    public function __construct($data, $rules)
+    {
+        parent::__construct(
+            app('translator'),
+            $data,
+            $rules,
+        );
+    }
+
+    protected function replaceAttributePlaceholder($message, $value)
+    {
+        $fieldId = (int) Str::after($value, 'field ');
+        $fieldTitle = CustomField::find($fieldId)->title;
+        $replacementString = "`{$fieldTitle}` field";
+        
+        return str_replace(
+            [':attribute', ':ATTRIBUTE', ':Attribute'],
+            [$replacementString, Str::upper($replacementString), Str::ucfirst($replacementString)],
+            $message
+        );
+    }
+}

--- a/tests/Feature/CustomFieldControllerTest.php
+++ b/tests/Feature/CustomFieldControllerTest.php
@@ -69,7 +69,7 @@ class CustomFieldControllerTest extends TestCase
                 'custom_fields' => [
                     $fieldId => 'Yeezus',
                 ],
-            ])->assertJsonFragment(["field_1" => ["The selected field 1 is invalid."]]);
+            ])->assertJsonFragment(["field_1" => ["The selected `favorite_album` field is invalid."]]);
     }
 
     /** @test */


### PR DESCRIPTION
This cleans up an annoyance where validators were using `field_1` and similar for validation. In this PR I create a custom validator to parse the awkward field names, find the related field, and use its title.