### PR TITLE
ADDED: Ability to makeCustomFields() and then call saveCustomFields() to commit the data at a later point in time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,9 +224,9 @@ To store responses to custom fields, just call `saveCustomFields()` and pass in 
 The `saveCustomFields` function can take in a Request or array.
 
 ```php
-$surveyResponse->saveCustomFields(['
-   
-']);
+$surveyResponse->saveCustomFields([
+   'Key' => 'Value'
+]);
 ```
 
 If you're submitting a form request, you can easily:
@@ -235,6 +235,21 @@ If you're submitting a form request, you can easily:
 Use App\...
 $surveyResponse->saveCustomFields($request->input);
 ```
+
+### Making then saving
+If you would like to make the custom fields without saving them immediately, you can call
+```php
+$surveyResponse->makeCustomFields([
+   'Key' => 'Value'
+]);
+```
+
+and then to save you need to call
+```php
+$surveyResponse->saveCustomFields();
+```
+
+This will set the `model_id` for you before saving the CustomField.
 
 ## Querying responses
 

--- a/src/Traits/HasCustomFieldResponses.php
+++ b/src/Traits/HasCustomFieldResponses.php
@@ -18,11 +18,29 @@ trait HasCustomFieldResponses
     }
 
     /**
-     * Save the given custom fields to the model.
+     * Save the custom fields to the model.
+     *   This parameter accepts a list of fields for immediate saving & backwards compatibility.
      *
      * @param $fields
      */
-    public function saveCustomFields($fields)
+    public function saveCustomFields($fields = [])
+    {
+        if (!empty($fields)) {
+            $this->makeCustomFields($fields);
+        }
+
+        $this->customFieldResponses->each(function(CustomFieldResponse $field) {
+            $field->model_id ??= $this->id; // set the ID now, if model did not exist when makeCustomFields() was called
+            $field->save();
+        });
+    }
+
+    /**
+     * Make the given custom fields but do not save.
+     *
+     * @param $fields
+     */
+    public function makeCustomFields($fields)
     {
         foreach ($fields as $key => $value) {
             $customField = CustomField::find((int) $key);
@@ -38,7 +56,7 @@ trait HasCustomFieldResponses
                 'model_type' => get_class($this),
             ]);
 
-            $customFieldResponse->save();
+            $this->customFieldResponses->push($customFieldResponse);
         }
     }
 


### PR DESCRIPTION
Adds the ability to `make()` custom fields without saving the immediately.

This allows you to attach custom field data to your model before it is saved using `$model->makeCustomFields()`

When you are ready to save the data, call `$model->saveCustomFields()` to set the `model_id` and store the data in the database