### PR TITLE
Add `group` to custom fields.

### DIFF
--- a/database/migrations/create_custom_fields_tables.php.stub
+++ b/database/migrations/create_custom_fields_tables.php.stub
@@ -17,6 +17,7 @@ return new class extends Migration
             $table->increments('id');
             $table->unsignedInteger('model_id');
             $table->string('model_type');
+            $table->string('group')->nullable();
             $table->string('type');
             $table->boolean('required')->default(false);
             $table->json('answers')->nullable();

--- a/src/Models/CustomField.php
+++ b/src/Models/CustomField.php
@@ -57,6 +57,7 @@ class CustomField extends Model
      * @var string[]
      */
     protected $fillable = [
+        'group',
         'type',
         'title',
         'description',

--- a/tests/Feature/CustomFieldTest.php
+++ b/tests/Feature/CustomFieldTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Givebutter\Tests\Feature;
+
+use Givebutter\LaravelCustomFields\Models\CustomField;
+use Givebutter\LaravelCustomFields\Models\CustomFieldResponse;
+use Givebutter\Tests\Support\Account;
+use Givebutter\Tests\Support\Contact;
+use Givebutter\Tests\Support\Survey;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Givebutter\Tests\TestCase;
+
+class CustomFieldTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_it_can_have_a_group()
+    {
+        $survey = Survey::create();
+
+        $survey->customFields()->save(
+            CustomField::factory()->make([
+                'group' => 'foo',
+            ])
+        );
+
+        $customField = $survey->customFields->first();
+
+        $this->assertEquals('foo', $customField->group);
+    }
+}


### PR DESCRIPTION
Allows grouping of custom fields using the `group` column. 

This allows a model like a `survey` to have a group/section of custom fields. This is an un-opinionated change that can serve various purposes.