### PR TITLE
Ignore not found IDs

### DIFF
--- a/src/Traits/HasCustomFields.php
+++ b/src/Traits/HasCustomFields.php
@@ -69,11 +69,9 @@ trait HasCustomFields
     protected function validationData(array|null $fields, Collection $customFields): array
     {
         return collect($fields)
-            ->mapWithKeys(function (mixed $field, int $key) use ($customFields) {
-                $id = $customFields->firstOrFail('id', $key)->id;
-
-                return ["field_{$id}" => $field];
-            })->toArray();
+            ->intersectByKeys($customFields->modelKeys())
+            ->mapWithKeys(fn ($v, $k) => ["field_$k" => $v])
+            ->toArray();
     }
 
     protected function validationRules(Collection $fields): array

--- a/src/Traits/HasCustomFields.php
+++ b/src/Traits/HasCustomFields.php
@@ -69,7 +69,7 @@ trait HasCustomFields
     protected function validationData(array|null $fields, Collection $customFields): array
     {
         return collect($fields)
-            ->intersectByKeys($customFields->modelKeys())
+            ->intersectByKeys(array_flip($customFields->modelKeys()))
             ->mapWithKeys(fn ($v, $k) => ["field_$k" => $v])
             ->toArray();
     }

--- a/tests/Feature/CustomFieldControllerTest.php
+++ b/tests/Feature/CustomFieldControllerTest.php
@@ -120,7 +120,8 @@ class CustomFieldControllerTest extends TestCase
                 'custom_fields' => [
                     $fieldId => 'Yeezus',
                 ],
-        ])->assertJsonFragment(["field_1" => ["The selected favorite_album is invalid."]]);
+            ])
+            ->assertJsonFragment(["field_1" => ["The selected favorite_album is invalid."]]);
     }
 
     /** @test */

--- a/tests/Feature/CustomFieldControllerTest.php
+++ b/tests/Feature/CustomFieldControllerTest.php
@@ -93,6 +93,7 @@ class CustomFieldControllerTest extends TestCase
     /** @test */
     public function invalid_data_throws_validation_exception()
     {
+        /** @var Survey $survey */
         $survey = Survey::create();
         $survey->customfields()->save(
             CustomField::factory()->make([
@@ -119,7 +120,7 @@ class CustomFieldControllerTest extends TestCase
                 'custom_fields' => [
                     $fieldId => 'Yeezus',
                 ],
-            ])->assertJsonFragment(["field_1" => ["The selected favorite_album is invalid."]]);
+        ])->assertJsonFragment(["field_1" => ["The selected favorite_album is invalid."]]);
     }
 
     /** @test */

--- a/tests/Feature/HasCustomFieldsTest.php
+++ b/tests/Feature/HasCustomFieldsTest.php
@@ -27,4 +27,22 @@ class HasCustomFieldsTest extends TestCase
         $this->assertCount(1, $model->fresh()->customFields);
         $this->assertEquals('Lil Wayne', $model->fresh()->customFields->first()->description);
     }
+
+    /** @test */
+    public function test_validating_unowned_custom_field_ids_are_ignored()
+    {
+        $model = Survey::create();
+
+        $customField = CustomField::factory()->make([
+            'model_id' => $model->id,
+            'model_type' => get_class($model),
+            'type' => 'text',
+        ]);
+
+        $validator = $model->validateCustomFields([
+            $customField->id + 1 => 'foo',
+        ]);
+
+        $this->assertTrue($validator->passes());
+    }
 }


### PR DESCRIPTION
Handle IDs that don't belong to a model more gracefully when validating.

### Reasoning

Previously, we were doing a `findOrFail` on the collection of custom fields. This results in an `ItemNotFoundException`. Unless the user handles this, this exception will bubble up to the exception handler.

One option considered was manually throwing a validation exception. I didn't go this route because `validateCustomFields()` returns a validator instance, and the user may not expect validation to be performed before calling `validate()` themselves.

I ended up deciding to quietly "discard" the invalid custom fields. This approach allows the user to handle it how they see fit before validating, without forcing their hand in dealing with our exceptions.