### PR TITLE
change publish name for configuration file

### DIFF
--- a/src/LaravelCustomFieldsServiceProvider.php
+++ b/src/LaravelCustomFieldsServiceProvider.php
@@ -22,7 +22,7 @@ class LaravelCustomFieldsServiceProvider extends ServiceProvider
     {
         $this->publishes([
             __DIR__ . '/../config/custom-fields.php' => config_path('custom-fields.php'),
-        ], 'custom-fields-config');
+        ], 'config');
 
         if (!class_exists('CreateCustomFieldsTables')) {
             $this->publishes([


### PR DESCRIPTION
In the documentation, for publish the configuration file it's write --tag="config" but in provider it's write : custom-fields-config.